### PR TITLE
Rename counter variables to avoid shadowing

### DIFF
--- a/sort-inline.inc
+++ b/sort-inline.inc
@@ -87,14 +87,14 @@ comparison_done:
 
 #define sortInline%1=>%0(%2=%3>%4) \
 	for ( \
-		new _buf[sizeof(%1)], _initial = true, _sz, _lo, _mid, _hi, _i, _j, _k, %3, %4, bool:%2; \
-		MergeSortBUImpl(_:%1, sizeof(%1), _buf, _initial, _sz, _lo, _mid, _hi, _i, _j, _k, _:%3, _:%4, %2); \
+		new _buf[sizeof(%1)], _initial = true, _sz, _lo, _mid, _hi, _si_i, _si_j, _si_k, %3, %4, bool:%2; \
+		MergeSortBUImpl(_:%1, sizeof(%1), _buf, _initial, _sz, _lo, _mid, _hi, _si_i, _si_j, _si_k, _:%3, _:%4, %2); \
 	)
 
 #define sortPartInline%1(%5)%0=>%0(%2=%3>%4) \
 	for ( \
-		new _buf[sizeof(%1)], _initial = true, _sz, _lo, _mid, _hi, _i, _j, _k, %3, %4, bool:%2; \
-		MergeSortBUImpl(_:%1, %5, _buf, _initial, _sz, _lo, _mid, _hi, _i, _j, _k, _:%3, _:%4, %2); \
+		new _buf[sizeof(%1)], _initial = true, _sz, _lo, _mid, _hi, _si_i, _si_j, _si_k, %3, %4, bool:%2; \
+		MergeSortBUImpl(_:%1, %5, _buf, _initial, _sz, _lo, _mid, _hi, _si_i, _si_j, _si_k, _:%3, _:%4, %2); \
 	)
 
 #define sortPlayersInline%0\32;%1=>%0(%2=%3>%4) \


### PR DESCRIPTION
A script including both this and [samp-logger](https://github.com/Southclaws/samp-logger) will produce variable shadowing warnings during compilation. Both use a variable named `_i` for different purposes.

As the variable used in this include is internal-only, I figured changing this include would be less disruptive. I renamed the counter variables to include a prefix (`si_`) to avoid the conflict.